### PR TITLE
fix front-page banner logo resizing

### DIFF
--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -10,29 +10,27 @@
   >
 
     <img
-      class="image-container"
-      src="{{ site.baseurl }}/assets/img/banner_page_1.jpg"
+      class="card-img"
+      src="{{ site.baseurl }}/assets/img/banner_qcd_1.jpg"
       alt="{{ page.title }}-image"
-      style="max-height: 150px; background-size: cover;"
     >
 
     <div
       class="
-        card-img-overlay
+        card-img-overlay bg-dark bg-opacity-50 
         d-flex flex-column
-        text-white text-start
         align-items-center align-content-center justify-content-center
       "
     >
-
-      <div class="display-5" style="width:90%; font-weight: 400;">
-        QuantOm
-      </div>
-
-      <div class="display-8" style="width:90%; font-weight: 400;">
+      <div class="landing-banner-title">
           <u>QUA</u>ntum chromodynamics
           <u>N</u>uclear
           <u>TOM</u>ography
+      </div>
+
+      <div class="landing-banner-text">
+        We image the 3D quark-gluon structure of nuclei, unraveling the
+        mysteries at the heart of matter.
       </div>
 
     </div>

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -10,7 +10,7 @@
   >
 
     <img
-      class="card-img"
+      class="image-container"
       src="{{ site.baseurl }}/assets/img/banner_page_1.jpg"
       alt="{{ page.title }}-image"
       style="max-height: 150px; background-size: cover;"

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -20,6 +20,7 @@
         card-img-overlay bg-dark bg-opacity-50 
         d-flex flex-column
         align-items-center align-content-center justify-content-center
+        px-4
       "
     >
       <div class="landing-banner-title">

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -6,14 +6,3 @@
 div.my-3 {
   background: linear-gradient(45deg, rgba(255, 255, 255, 0), rgba(222, 255, 222, 108), rgba(255, 255, 255, 0));
 }
-
-.image-container {
-  height: 180px; /* or any desired height on the parent */
-}
-
-img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;  /* cover | contain */
-}

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -6,3 +6,14 @@
 div.my-3 {
   background: linear-gradient(45deg, rgba(255, 255, 255, 0), rgba(222, 255, 222, 108), rgba(255, 255, 255, 0));
 }
+
+.image-container {
+  height: 180px; /* or any desired height on the parent */
+}
+
+img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;  /* cover | contain */
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -101,11 +101,8 @@
 
 .landing-banner-title {
   @extend .text-center;
-  @extend .d-none;
-  @extend .d-md-block;
   font-size: calc(0.75rem + 1.75vw);
   color: $orange;
-  width: 90%;
   font-weight: 600;
 }
 
@@ -115,5 +112,4 @@
   @extend .d-none;
   @extend .d-sm-block;
   font-size: calc(0.75rem + 1.3vw);
-  width: 90%;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -101,7 +101,7 @@
 
 .landing-banner-title {
   @extend .text-center;
-  font-size: calc(0.75rem + 1.75vw);
+  font-size: clamp(1px, calc(0.75rem + 1.75vw), 46px);
   color: $orange;
   font-weight: 600;
 }
@@ -111,5 +111,5 @@
   @extend .text-center;
   @extend .d-none;
   @extend .d-sm-block;
-  font-size: calc(0.75rem + 1.3vw);
+  font-size: clamp(1px, calc(0.75rem + 1.3vw), 37px);
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -80,7 +80,6 @@
 // overwrite Bootstrap's default standard CSS variables
 :root {
   --bs-body-font-family: "Poppins", sans-serif;
-  --bs-body-font-size: 1.25rem;
 }
 
 .breadcrumb {
@@ -93,9 +92,28 @@
   text-decoration: none;
 }
 
-// our own code from here on
+// our own code from here on (can be either SCSS or CSS)
 .btn-white {
   @extend .btn-light;
   --bs-btn-bg: #ffffff !important;  // override the parent's
   --bs-btn-border-color: #ffffff !important;  // override the parent's
+}
+
+.landing-banner-title {
+  @extend .text-center;
+  @extend .d-none;
+  @extend .d-md-block;
+  font-size: calc(0.75rem + 1.75vw);
+  color: $orange;
+  width: 90%;
+  font-weight: 600;
+}
+
+.landing-banner-text {
+  @extend .text-light;
+  @extend .text-center;
+  @extend .d-none;
+  @extend .d-sm-block;
+  font-size: calc(0.75rem + 1.3vw);
+  width: 90%;
 }


### PR DESCRIPTION
The banner is too long for mobile devices. It doens't resize well. 
![Screenshot from 2025-02-12 11-51-04](https://github.com/user-attachments/assets/682c971a-f51f-4bcc-8701-7d4e42594291)
Wit the fix it looks like this on mobile
![image](https://github.com/user-attachments/assets/30941eaf-7621-414d-bfd2-716fd8dc89cb)
